### PR TITLE
[Adapter-RTBH] add support for  properietary viewability parameter

### DIFF
--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -96,12 +96,23 @@ function mapImpression(slot) {
     id: slot.bidId,
     banner: mapBanner(slot),
     native: mapNative(slot),
-    tagid: slot.adUnitCode.toString()
+    tagid: slot.adUnitCode.toString(),
   };
 
   const bidfloor = parseFloat(slot.params.bidfloor);
   if (bidfloor) {
     imp.bidfloor = bidfloor
+  }
+
+  const viewability = parseFloat(slot.params.viewability);
+  if (viewability) {
+    imp.metric = [{
+      type: 'viewability',
+      vendor: 'proprietary',
+      value: isNaN(viewability)
+        ? 0
+        : viewability > 1 ? 0 : viewability
+    }];
   }
 
   return imp;

--- a/modules/rtbhouseBidAdapter.md
+++ b/modules/rtbhouseBidAdapter.md
@@ -24,7 +24,8 @@ Please reach out to pmp@rtbhouse.com to receive your own
                        params: {
                            region: 'prebid-eu',
                            publisherId: 'PREBID_TEST_ID',
-                           bidfloor: 0.01  // optional
+                           bidfloor: 0.01,  // optional
+                           viewability: 0.1 // viewability according to MRC, range 0 -> 1 
                        }
                    }
                ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "1.39.0",
+  "version": "1.40.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -158,6 +158,15 @@ describe('RTBHouseAdapter', () => {
       expect(data.imp[0].bidfloor).to.equal(0.01)
     });
 
+    it('should include viewability in request if available', () => {
+      const bidRequest = Object.assign([], bidRequests);
+      bidRequest[0].params.viewability = 0.1;
+      const request = spec.buildRequests(bidRequest, bidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.imp[0].metric[0].value).to.equal(0.1);
+      expect(data.imp[0].metric[0].type).to.equal('viewability');
+    });
+
     describe('native imp', () => {
       function basicRequest(extension) {
         return Object.assign({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
